### PR TITLE
Add missing GAME_DURATION and EXTRA_OVERTIME_DURATION specs

### DIFF
--- a/src/lugo4py/src/specs.py
+++ b/src/lugo4py/src/specs.py
@@ -4,6 +4,16 @@ max_y_coordinate = 100 * BASE_UNIT
 goal_width = 30 * BASE_UNIT
 player_max_speed = 100.0
 
+# GAME_DURATION Number of turns in the regular phase of the game.
+# After this many turns, if one team is ahead, the game ends.
+# If the score is tied, overtime may be applied if the game it configured to accept golden goal
+GAME_DURATION = 6000
+
+# EXTRA_OVERTIME_DURATION Number of additional turns granted if the game is tied
+# at the end of the regular duration.
+# If still tied after this period, the match ends in a draw.
+EXTRA_OVERTIME_DURATION = 2400
+
 # PLAYER_SIZE is the size of each player
 PLAYER_SIZE = 4 * BASE_UNIT
 


### PR DESCRIPTION
## Problem

`GAME_DURATION` and `EXTRA_OVERTIME_DURATION` exist in the Go and JS clients but are missing from the Python one. There is no way to read the match length from `lugo4py`, so bot authors end up hardcoding 6000.

The value is easy to get wrong. The website docs say 1200 turns while the server runs 6000.

## Fix

Adds both constants with the same values and comments used in the other clients.

```python
import lugo4py

lugo4py.GAME_DURATION            # 6000
lugo4py.EXTRA_OVERTIME_DURATION  # 2400
```

The JS client got these in 2a72774 (adding missing specs). This brings the Python client to parity.
